### PR TITLE
website: use Title Case, add sub-repos to navigation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,26 @@ languageCode = "en-us"
 title = "The Linux Userspace API Group"
 theme = "hugo-book"
 
+[[menu.after]]
+  name = "General Documentation"
+  url = "https://uapi-group.org/docs"
+  weight = 10
+[[menu.after]]
+  name = "Specifications"
+  url = "https://uapi-group.org/specifications"
+  weight = 11
+[[menu.after]]
+  name = "Kernel Features"
+  url = "https://uapi-group.org/kernel"
+  weight = 12
+[[menu.after]]
+  name = "-"
+  weight = 20
+[[menu.after]]
+  name = "Collaborate on Github"
+  url = "https://github.com/uapi-group"
+  weight = 20
+
 [markup.goldmark.renderer]
   unsafe = true # Allow HTML in md files
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,17 +1,18 @@
 ---
-title: The Linux Userspace API (UAPI) group
+title: The Linux Userspace API (UAPI) Group
+BookToC: false
 ---
 
 <span style="float:right"> ![uapi-group.png](/uapi-group.png) </span>
 
-# The Linux Userspace API (UAPI) group
+# The Linux Userspace API (UAPI) Group
 
 The userspace API ("uapi") group is a community for people with an interest in innovating how we build, deploy, and run modern Linux operating systems.
 It serves as a central gathering place for specs, documentation, and ideas.
 
 Follow [@uapi-group](https://twitter.com/uapi_group) on twitter to catch the latest news!
 
-## Generic documents, minutes, and glossary
+## Generic Documents, Minutes, and Glossary
 
 Please find generic documents like meeting / summit minutes and a glossary of terms used across uapi-group documents at https://uapi-group.org/docs.
 


### PR DESCRIPTION
This change uses Title Case consistently and adds links to kernel, docs, and specifications sub-pages to the left hand side navigation menu.

Also, the right hand side table of contents is removed.