### PR TITLE
Elaborate on group purpose, move group engagement section up

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,14 +7,16 @@ BookToC: false
 
 # The Linux Userspace API (UAPI) Group
 
-The userspace API ("uapi") group is a cross-distro community for people with an interest in innovating how we build, deploy, run, and safely update modern Linux operating systems.
+The userspace API ("uapi") group is a community for people with an interest in innovating how we build, deploy, run, and safely update modern Linux operating systems.
 It serves as a central gathering place for specs, documentation, and ideas.
 
-In scope of the group are secure boot mechanisms, kernel / disk image formats, TPM usage, safe and secure updates, and related topics.
+The group is in the process of constituting itself and is exploring the problem space relevant to us.
+In the general scope of the group are trusted boot mechanisms, kernel / disk image formats, TPM usage, safe and secure updates, and related topics.
 The group also cares about interop of image-based and/or immutable Linux distributions.
+The group is in its inception, so the list of topics is by no means complete - other relevant topics related to the above might be added in the future.
 
-The group was founded to discuss and align on common mechanisms, to prevent creating quasi standards by going with implementations first.
-Interested engineers are invited to join the discussions, and to represent the directions and interests of their projects and distributions.
+The UAPI group aims to establish specifications for common concepts shared among relevant parties.
+We are open to anyone who has an interest in constructive collaboration to to join the discussions, and to represent the directions and interests of their projects and distributions.
 
 ## Engage with the Group
 
@@ -26,7 +28,7 @@ Check out the group's repos at the [UAPI group github org](https://github.com/ua
 To engage with specific content please file issues and / or PRs directly to the [specifications](https://github.com/uapi-group/specifications/),
 [docs](https://github.com/uapi-group/docs/), and [kernel feature ideas](https://github.com/uapi-group/kernel-features/) repositories, respectively.
 
-To stay up to date on the group's activities there's also a Twitter account you can follow: [@uapi-group](https://twitter.com/uapi-group).
+To stay up to date on the group's activities there's also a Twitter account you can follow: [uapi-group](https://twitter.com/uapi_group).
 
 ## UAPI Group Specifications
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,35 +7,31 @@ BookToC: false
 
 # The Linux Userspace API (UAPI) Group
 
-The userspace API ("uapi") group is a community for people with an interest in innovating how we build, deploy, run, and safely update modern Linux operating systems.
+The userspace API ("uapi") group is a community for people with an interest in innovating how we build, deploy, run, and securely update modern Linux operating systems.
 It serves as a central gathering place for specs, documentation, and ideas.
 
-The group is in the process of constituting itself and is exploring the problem space relevant to us.
+The group is in the process of constituting itself and is exploring the problem space.
 In the general scope of the group are trusted boot mechanisms, kernel / disk image formats, TPM usage, safe and secure updates, and related topics.
 The group also cares about interop of image-based and/or immutable Linux distributions.
-The group is in its inception, so the list of topics is by no means complete - other relevant topics related to the above might be added in the future.
+The group is in its inception, so the list of topics is by no means complete.
+Other relevant topics related to the above might be added in the future.
 
 The UAPI group aims to establish specifications for common concepts shared among relevant parties.
-We are open to anyone who has an interest in constructive collaboration to to join the discussions, and to represent the directions and interests of their projects and distributions.
+We are open to anyone who has an interest in constructive collaboration to join the discussions, and to represent the directions and interests of their projects and distributions.
 
-Contributing members include people from 
-Red Hat / Fedora CoreOS ( [@travier](https://github.com/travier), [@dvdhrm](https://github.com/dvdhrm), [@gicmo](https://github.com/gicmo)),
-Flatpak ([@wjt](https://github.com/wjt)), mkosi ([@behrmann](https://github.com/behrmann)),
-gnomeos ([@alatiera](https://github.com/alatiera)),
-Meta ([DaanDeMeyer](https://github.com/DaanDeMeyer)),
-Arch Linux ([@Foxboron](https://github.com/Foxboron)),
-systemd ([@bluca](https://github.com/bluca), [poettering](https://github.com/poettering), [@brauner](https://github.com/brauner)),
-Flatcar ([@jepio](https://github.com/jepio), [@pothos](https://github.com/pothos), [@t-lo](https://github.com/t-lo))
-and others.
-
+Contributing members include people from Ubuntu Core, Debian, GNOME OS, Fedora CoreOS, Endless OS, Arch Linux, SUSE, Flatcar, 
+systemd, image-builder/osbuild, mkosi, tpm2-software, System Transparency, buildstream, BTRFS, rpm-ostree,
+Microsoft, Amazon, and Meta.
 
 ## Engage with the Group
 
 Our main means of engagement is Github.
-Please check out the group's [Github discussions](https://github.com/orgs/uapi-group/discussions) for general ongoing conversations - don't hesitate to tune in and share your thoughts!
-Feel free to start a new discussion if none exists for whatever brings you here - but please keep the group's focus in mind and do not stray off-topic.
+Please check out the group's [Github discussions](https://github.com/orgs/uapi-group/discussions) for general ongoing conversations.
+Don't hesitate to tune in and share your thoughts!
+Feel free to start a new discussion if none exists for whatever brings you here.
+Please keep the group's focus in mind and do not stray off-topic.
 
-Check out the group's repos at the [UAPI group github org](https://github.com/uapi-group) to get an overview of existing work.
+Check out the group's repos at the [uapi group github org](https://github.com/uapi-group) to get an overview of existing work.
 To engage with specific content please file issues and / or PRs directly to the [specifications](https://github.com/uapi-group/specifications/),
 [docs](https://github.com/uapi-group/docs/), and [kernel feature ideas](https://github.com/uapi-group/kernel-features/) repositories, respectively.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,10 +7,25 @@ BookToC: false
 
 # The Linux Userspace API (UAPI) Group
 
-The userspace API ("uapi") group is a community for people with an interest in innovating how we build, deploy, and run modern Linux operating systems.
+The userspace API ("uapi") group is a cross-distro community for people with an interest in innovating how we build, deploy, run, and safely update modern Linux operating systems.
 It serves as a central gathering place for specs, documentation, and ideas.
 
-Follow [@uapi-group](https://twitter.com/uapi-group) on twitter to catch the latest news!
+In scope of the group are secure boot mechanisms, kernel / disk image formats, TPM usage, safe and secure updates, and related topics.
+The group also cares about interop of image-based and/or immutable Linux distributions.
+
+The group was founded to discuss and align on common mechanisms, to prevent creating quasi standards by going with implementations first.
+Interested engineers are invited to join the discussions, and to represent the directions and interests of their projects and distributions.
+
+## Engage with the Group
+
+Our main means of engagement is Github.
+Please check out the group's [Github discussions](https://github.com/orgs/uapi-group/discussions) for general ongoing conversations - don't hesitate to tune in and share your thoughts!
+Feel free to start a new discussion if none exists for whatever brings you here - but please keep the group's focus in mind and do not stray off-topic.
+
+To engage with specific content please file issues and / or PRs directly to the [specifications](https://github.com/uapi-group/specifications/),
+[docs](https://github.com/uapi-group/docs/), and [kernel feature ideas](https://github.com/uapi-group/kernel-features/) repositories, respectively.
+
+To stay up to date on the group's activities there's also a Twitter account you can follow: [@uapi-group](https://twitter.com/uapi-group).
 
 ## UAPI Group Specifications
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -18,6 +18,17 @@ The group is in its inception, so the list of topics is by no means complete - o
 The UAPI group aims to establish specifications for common concepts shared among relevant parties.
 We are open to anyone who has an interest in constructive collaboration to to join the discussions, and to represent the directions and interests of their projects and distributions.
 
+Contributing members include people from 
+Red Hat / Fedora CoreOS ( [@travier](https://github.com/travier), [@dvdhrm](https://github.com/dvdhrm), [@gicmo](https://github.com/gicmo)),
+Flatpak ([@wjt](https://github.com/wjt)), mkosi ([@behrmann](https://github.com/behrmann)),
+gnomeos ([@alatiera](https://github.com/alatiera)),
+Meta ([DaanDeMeyer](https://github.com/DaanDeMeyer)),
+Arch Linux ([@Foxboron](https://github.com/Foxboron)),
+systemd ([@bluca](https://github.com/bluca), [poettering](https://github.com/poettering), [@brauner](https://github.com/brauner)),
+Flatcar ([@jepio](https://github.com/jepio), [@pothos](https://github.com/pothos), [@t-lo](https://github.com/t-lo))
+and others.
+
+
 ## Engage with the Group
 
 Our main means of engagement is Github.


### PR DESCRIPTION
This change adds introductory text to elaborate on the group's raison d'être based on initial feedback we received on social media immediately after launch.

The change also elaborates on ways to engage with the group and makes the engagement section more central by moving it up.